### PR TITLE
Fix running Gitlab container locally

### DIFF
--- a/dev/run_gitlab_in_docker.sh
+++ b/dev/run_gitlab_in_docker.sh
@@ -94,9 +94,6 @@ echo "token-string-here123" > "$repo_root_directory"/gitlab_token.txt
 
 cecho b 'Starting GitLab complete!'
 echo ''
-cecho b 'GitLab version:'
-curl -H "Authorization:Bearer $(cat "$repo_root_directory"/gitlab_token.txt)" http://localhost/api/v4/version
-echo ''
 cecho b 'GitLab web UI URL (user: root, password: password)'
 echo 'http://localhost'
 echo ''


### PR DESCRIPTION
(as on GHA it already works well)

* make it REALLY delete GitLab container data
  on each (re)start, as it's the only way to
  make GitLab run this way stable that I have
  found,
* quote paths as we started to rm -rf "$stuff"
  and it could end up badly quickly
* make stop_gitlab work (thanks mkjmdski!)