### PR TITLE
Faster run and less cluttered debug output

### DIFF
--- a/gitlabform/configuration/groups.py
+++ b/gitlabform/configuration/groups.py
@@ -1,3 +1,4 @@
+import functools
 from logging import debug
 
 from gitlabform.configuration.core import ConfigurationCore
@@ -20,6 +21,7 @@ class ConfigurationGroups(ConfigurationCore):
                 groups.append(group_name)
         return sorted(groups)
 
+    @functools.lru_cache()
     def get_effective_config_for_group(self, group) -> dict:
         """
         :param group: "group_name"

--- a/gitlabform/configuration/groups.py
+++ b/gitlabform/configuration/groups.py
@@ -2,6 +2,7 @@ import functools
 from logging import debug
 
 from gitlabform.configuration.core import ConfigurationCore
+from gitlabform.ui import to_str
 
 
 class ConfigurationGroups(ConfigurationCore):
@@ -29,10 +30,10 @@ class ConfigurationGroups(ConfigurationCore):
         """
 
         common_config = self.get_common_config()
-        debug("Common config: %s" % common_config)
+        debug("Common config: %s", to_str(common_config))
 
         group_config = self.get_group_config(group)
-        debug("Group config: %s" % group_config)
+        debug("Group config: %s", to_str(group_config))
 
         if not group_config and not common_config:
             return {}
@@ -62,21 +63,26 @@ class ConfigurationGroups(ConfigurationCore):
         for element in elements:
             if not last_element:
                 effective_config = self.get_group_config(element)
-                debug("First level config for '%s': %s" % (element, effective_config))
+                debug(
+                    "First level config for '%s': %s", element, to_str(effective_config)
+                )
                 last_element = element
             else:
                 next_level_subgroup = last_element + "/" + element
                 next_level_subgroup_config = self.get_group_config(next_level_subgroup)
                 debug(
-                    "Config for '%s': %s"
-                    % (next_level_subgroup, next_level_subgroup_config)
+                    "Config for '%s': %s",
+                    next_level_subgroup,
+                    to_str(next_level_subgroup_config),
                 )
                 effective_config = self.merge_configs(
                     effective_config, next_level_subgroup_config
                 )
                 debug(
-                    "Merged previous level config for '%s' with config for '%s': %s"
-                    % (last_element, next_level_subgroup, effective_config)
+                    "Merged previous level config for '%s' with config for '%s': %s",
+                    last_element,
+                    next_level_subgroup,
+                    to_str(effective_config),
                 )
                 last_element = last_element + "/" + element
 

--- a/gitlabform/configuration/projects_and_groups.py
+++ b/gitlabform/configuration/projects_and_groups.py
@@ -1,3 +1,4 @@
+import functools
 from logging import debug
 
 from gitlabform.configuration.groups import ConfigurationGroups
@@ -18,6 +19,7 @@ class ConfigurationProjectsAndGroups(ConfigurationGroups):
                 projects.append(element)
         return sorted(projects)
 
+    @functools.lru_cache()
     def get_effective_config_for_project(self, group_and_project) -> dict:
         """
         :param group_and_project: "project_group/project_name"

--- a/gitlabform/configuration/projects_and_groups.py
+++ b/gitlabform/configuration/projects_and_groups.py
@@ -2,6 +2,7 @@ import functools
 from logging import debug
 
 from gitlabform.configuration.groups import ConfigurationGroups
+from gitlabform.ui import to_str
 
 
 class ConfigurationProjectsAndGroups(ConfigurationGroups):
@@ -30,23 +31,29 @@ class ConfigurationProjectsAndGroups(ConfigurationGroups):
         """
 
         common_config = self.get_common_config()
-        debug("Common config: %s" % common_config)
+        debug("Common config: %s", to_str(common_config))
 
         group, project = group_and_project.rsplit("/", 1)
         if "/" in group:
             group_config = self.get_effective_subgroup_config(group)
         else:
             group_config = self.get_group_config(group)
-        debug("Effective group/subgroup config: %s" % group_config)
+        debug("Effective group/subgroup config: %s", to_str(group_config))
 
         project_config = self.get_project_config(group_and_project)
-        debug("Project config: %s" % project_config)
+        debug("Project config: %s", to_str(project_config))
 
         common_and_group_config = self.merge_configs(common_config, group_config)
-        debug("Effective config common+group/subgroup: %s" % common_and_group_config)
+        debug(
+            "Effective config common+group/subgroup: %s",
+            to_str(common_and_group_config),
+        )
 
         effective_config = self.merge_configs(common_and_group_config, project_config)
-        debug("Effective config common+group/subgroup+project: %s" % effective_config)
+        debug(
+            "Effective config common+group/subgroup+project: %s",
+            to_str(effective_config),
+        )
 
         return effective_config
 

--- a/gitlabform/gitlab/core.py
+++ b/gitlabform/gitlab/core.py
@@ -15,7 +15,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from gitlabform.configuration import Configuration
-from gitlabform.ui import to_json_str
+from gitlabform.ui import to_str
 
 
 class GitLabCore:
@@ -188,12 +188,12 @@ class GitLabCore:
 
         url = f"{self.url}/api/v4/{self._format_with_url_encoding(path_as_format_string, args)}"
         if dict_data:
-            debug(f"===> data = {to_json_str(dict_data)}")
+            debug(f"===> data = {to_str(dict_data)}")
             response = self.session.request(
                 method, url, data=dict_data, timeout=self.timeout
             )
         elif json_data:
-            debug(f"===> json = {to_json_str(json_data)}")
+            debug(f"===> json = {to_str(json_data)}")
             response = self.session.request(
                 method, url, json=json_data, timeout=self.timeout
             )
@@ -212,9 +212,9 @@ class GitLabCore:
                 )
             else:
                 data_output = (
-                    f"data='{to_json_str(dict_data)}' "
+                    f"data='{to_str(dict_data)}' "
                     if dict_data
-                    else f"json='{to_json_str(json_data)}' "
+                    else f"json='{to_str(json_data)}' "
                 )
                 raise UnexpectedResponseException(
                     f"Request url='{url}', method={method}, {data_output}failed -"
@@ -224,7 +224,7 @@ class GitLabCore:
                     response.text,
                 )
         if response.json():
-            debug(f"<--- json = {to_json_str(response.json())}")
+            debug(f"<--- json = {to_str(response.json())}")
         return response
 
     @staticmethod

--- a/gitlabform/gitlab/projects.py
+++ b/gitlabform/gitlab/projects.py
@@ -214,7 +214,7 @@ class GitLabProjects(GitLabCore):
         #     'setting2': value2,
         # }
         # ..as documented at: https://docs.gitlab.com/ce/api/projects.html#edit-project
-        self._make_requests_to_api(
+        return self._make_requests_to_api(
             "projects/%s",
             project_and_group_name,
             "PUT",

--- a/gitlabform/gitlab/users.py
+++ b/gitlabform/gitlab/users.py
@@ -16,7 +16,7 @@ class GitLabUsers(GitLabCore):
     def get_user_by_name(self, username, user_id=None):
         if not user_id:
             user_id = self._get_user_id(username)
-        return self._get_user(user_id)
+        return self._make_requests_to_api("users/%s", str(user_id), "GET")
 
     def delete_user(self, username, user_id=None):
         if not user_id:

--- a/gitlabform/processors/abstract_processor.py
+++ b/gitlabform/processors/abstract_processor.py
@@ -64,5 +64,22 @@ class AbstractProcessor(ABC):
     ):
         pass
 
-    def _print_diff(self, project_or_project_and_group: str, configuration_to_process):
+    def _print_diff(self, project_or_project_and_group: str, entity_config):
         verbose(f"Diffing for section '{self.configuration_name}' is not supported yet")
+
+    @staticmethod
+    def _needs_update(
+        entity_in_gitlab: dict,
+        entity_in_configuration: dict,
+    ):
+        # in configuration we often don't define every key value because we rely on the defaults.
+        # that's why GitLab API often returns many more keys than we have in the configuration.
+        # so to decide if the entity should be update we are checking only the values of the ones
+        # that are in the configuration.
+
+        for key in entity_in_gitlab.keys():
+            if key in entity_in_configuration.keys():
+                if entity_in_gitlab[key] != entity_in_configuration[key]:
+                    return True
+
+        return False

--- a/gitlabform/processors/group/group_settings_processor.py
+++ b/gitlabform/processors/group/group_settings_processor.py
@@ -1,17 +1,12 @@
-from logging import debug
-from cli_ui import debug as verbose
-
 from gitlabform.gitlab import GitLab
-from gitlabform.processors.abstract_processor import AbstractProcessor
+from gitlabform.processors.single_entity_processor import SingleEntityProcessor
 
 
-class GroupSettingsProcessor(AbstractProcessor):
+class GroupSettingsProcessor(SingleEntityProcessor):
     def __init__(self, gitlab: GitLab):
-        super().__init__("group_settings", gitlab)
-
-    def _process_configuration(self, group: str, configuration: dict):
-        group_settings = configuration["group_settings"]
-        debug("Group settings BEFORE: %s", self.gitlab.get_group_settings(group))
-        verbose(f"Setting group settings: {group_settings}")
-        self.gitlab.put_group_settings(group, group_settings)
-        debug("Group settings AFTER: %s", self.gitlab.get_group_settings(group))
+        super().__init__(
+            "group_settings",
+            gitlab,
+            get_method_name="get_group_settings",
+            edit_method_name="put_group_settings",
+        )

--- a/gitlabform/processors/multiple_entities_processor.py
+++ b/gitlabform/processors/multiple_entities_processor.py
@@ -42,7 +42,7 @@ class MultipleEntitiesProcessor(AbstractProcessor, metaclass=abc.ABCMeta):
         self._find_duplicates(project_or_group, entities_in_configuration)
 
         entities_in_gitlab = self.list_method(project_or_group)
-        debug(f"{self.configuration_name} BEFORE: {entities_in_gitlab}")
+        debug(f"{self.configuration_name} BEFORE: ^^^")
 
         for entity_name, entity_config in entities_in_configuration.items():
 
@@ -67,12 +67,14 @@ class MultipleEntitiesProcessor(AbstractProcessor, metaclass=abc.ABCMeta):
                         self.edit_method(
                             project_or_group, entity_in_gitlab, entity_config
                         )
+                        debug(f"{self.configuration_name} AFTER: ^^^")
                     else:
                         verbose(
                             f"Recreating {entity_name} of {self.configuration_name} in {project_or_group}"
                         )
                         self.delete_method(project_or_group, entity_in_gitlab)
                         self.add_method(project_or_group, entity_config)
+                        debug(f"{self.configuration_name} AFTER: ^^^")
                 else:
                     verbose(
                         f"{entity_name} of {self.configuration_name} in {project_or_group} doesn't need an update."
@@ -90,10 +92,7 @@ class MultipleEntitiesProcessor(AbstractProcessor, metaclass=abc.ABCMeta):
                         f"Adding {entity_name} of {self.configuration_name} in {project_or_group}"
                     )
                     self.add_method(project_or_group, entity_config)
-
-        debug(
-            f"{self.configuration_name} AFTER: %s", self.list_method(project_or_group)
-        )
+                    debug(f"{self.configuration_name} AFTER: ^^^")
 
     def _find_duplicates(self, project_or_group: str, entities_in_configuration: dict):
         for first_key, first_value in entities_in_configuration.items():
@@ -133,22 +132,5 @@ class MultipleEntitiesProcessor(AbstractProcessor, metaclass=abc.ABCMeta):
         for entity_in_gitlab in entities_in_gitlab:
             if self.defining.matches(entity_in_gitlab, entity_in_configuration):
                 return entity_in_gitlab
-
-        return False
-
-    @staticmethod
-    def _needs_update(
-        entity_in_gitlab: dict,
-        entity_in_configuration: dict,
-    ):
-        # in configuration we often don't define every key value because we rely on the defaults.
-        # that's why GitLab API often returns many more keys than we have in the configuration.
-        # so to decide if the entity should be update we are checking only the values of the ones
-        # that are in the configuration.
-
-        for key in entity_in_gitlab.keys():
-            if key in entity_in_configuration.keys():
-                if entity_in_gitlab[key] != entity_in_configuration[key]:
-                    return True
 
         return False

--- a/gitlabform/processors/project/project_processor.py
+++ b/gitlabform/processors/project/project_processor.py
@@ -9,12 +9,9 @@ class ProjectProcessor(AbstractProcessor):
         super().__init__("project", gitlab)
 
     def _process_configuration(self, project_and_group: str, configuration: dict):
-        project = configuration["project"]
-        if project:
-            if "archive" in project:
-                if project["archive"]:
-                    verbose("Archiving project...")
-                    self.gitlab.archive(project_and_group)
-                else:
-                    verbose("Unarchiving project...")
-                    self.gitlab.unarchive(project_and_group)
+        if configuration["project"].get("archive"):
+            verbose("Archiving project...")
+            self.gitlab.archive(project_and_group)
+        else:
+            verbose("Unarchiving project...")
+            self.gitlab.unarchive(project_and_group)

--- a/gitlabform/processors/project/project_push_rules_processor.py
+++ b/gitlabform/processors/project/project_push_rules_processor.py
@@ -1,34 +1,13 @@
-from logging import debug
-from cli_ui import debug as verbose
-
 from gitlabform.gitlab import GitLab
-from gitlabform.processors.abstract_processor import AbstractProcessor
-from gitlabform.processors.util.difference_logger import DifferenceLogger
+from gitlabform.processors.single_entity_processor import SingleEntityProcessor
 
 
-class ProjectPushRulesProcessor(AbstractProcessor):
+class ProjectPushRulesProcessor(SingleEntityProcessor):
     def __init__(self, gitlab: GitLab):
-        super().__init__("project_push_rules", gitlab)
-
-    def _process_configuration(self, project_and_group: str, configuration: dict):
-        push_rules = configuration["project_push_rules"]
-        old_project_push_rules = self.gitlab.get_project_push_rules(project_and_group)
-        debug("Project push rules settings BEFORE: %s", old_project_push_rules)
-        if old_project_push_rules:
-            verbose(f"Updating project push rules: {push_rules}")
-            self.gitlab.put_project_push_rules(project_and_group, push_rules)
-        else:
-            verbose(f"Creating project push rules: {push_rules}")
-            self.gitlab.post_project_push_rules(project_and_group, push_rules)
-        debug(
-            "Project push rules AFTER: %s",
-            self.gitlab.get_project_push_rules(project_and_group),
-        )
-
-    def _print_diff(self, project_and_group: str, push_rules):
-        current_push_rules = self.gitlab.get_project_push_rules(project_and_group)
-        DifferenceLogger.log_diff(
-            "Project %s push rules changes" % project_and_group,
-            current_push_rules,
-            push_rules,
+        super().__init__(
+            "project_push_rules",
+            gitlab,
+            get_method_name="get_project_push_rules",
+            edit_method_name="put_project_push_rules",
+            add_method_name="post_project_push_rules",
         )

--- a/gitlabform/processors/project/project_settings_processor.py
+++ b/gitlabform/processors/project/project_settings_processor.py
@@ -1,32 +1,12 @@
-from logging import debug
-from cli_ui import debug as verbose
-
 from gitlabform.gitlab import GitLab
-from gitlabform.processors.abstract_processor import AbstractProcessor
-from gitlabform.processors.util.difference_logger import DifferenceLogger
+from gitlabform.processors.single_entity_processor import SingleEntityProcessor
 
 
-class ProjectSettingsProcessor(AbstractProcessor):
+class ProjectSettingsProcessor(SingleEntityProcessor):
     def __init__(self, gitlab: GitLab):
-        super().__init__("project_settings", gitlab)
-
-    def _process_configuration(self, project_and_group: str, configuration: dict):
-        project_settings = configuration["project_settings"]
-        debug(
-            "Project settings BEFORE: %s",
-            self.gitlab.get_project_settings(project_and_group),
-        )
-        verbose(f"Setting project settings: {project_settings}")
-        self.gitlab.put_project_settings(project_and_group, project_settings)
-        debug(
-            "Project settings AFTER: %s",
-            self.gitlab.get_project_settings(project_and_group),
-        )
-
-    def _print_diff(self, project_and_group: str, project_settings):
-        current_project_settings = self.gitlab.get_project_settings(project_and_group)
-        DifferenceLogger.log_diff(
-            "Project %s changes" % project_and_group,
-            current_project_settings,
-            project_settings,
+        super().__init__(
+            "project_settings",
+            gitlab,
+            get_method_name="get_project_settings",
+            edit_method_name="put_project_settings",
         )

--- a/gitlabform/processors/single_entity_processor.py
+++ b/gitlabform/processors/single_entity_processor.py
@@ -1,0 +1,58 @@
+from logging import debug
+from cli_ui import debug as verbose
+
+import abc
+from typing import Callable
+
+from gitlabform.gitlab import GitLab
+from gitlabform.processors.abstract_processor import AbstractProcessor
+from gitlabform.processors.util.difference_logger import DifferenceLogger
+
+
+class SingleEntityProcessor(AbstractProcessor, metaclass=abc.ABCMeta):
+    def __init__(
+        self,
+        configuration_name: str,
+        gitlab: GitLab,
+        get_method_name: str,
+        edit_method_name: str,
+        add_method_name: str = None,
+    ):
+        super().__init__(configuration_name, gitlab)
+        self.get_method: Callable = getattr(self.gitlab, get_method_name)
+        self.edit_method: Callable = getattr(self.gitlab, edit_method_name)
+        if add_method_name:
+            self.add_method: Callable = getattr(self.gitlab, add_method_name)
+        else:
+            self.add_method = None
+
+    def _process_configuration(self, project_or_group: str, configuration: dict):
+
+        entity_config = configuration[self.configuration_name]
+
+        entity_in_gitlab = self.get_method(project_or_group)
+        debug(f"{self.configuration_name} BEFORE: ^^^")
+
+        if entity_in_gitlab:
+            if self._needs_update(entity_in_gitlab, entity_config):
+                verbose(f"Editing {self.configuration_name} in {project_or_group}")
+                self.edit_method(project_or_group, entity_config)
+                debug(f"{self.configuration_name} AFTER: ^^^")
+            else:
+                verbose(
+                    f"{self.configuration_name} in {project_or_group} doesn't need an update."
+                )
+        else:
+            verbose(f"Adding {self.configuration_name} in {project_or_group}")
+            self.add_method(project_or_group, entity_config)
+            debug(f"{self.configuration_name} AFTER: ^^^")
+
+    def _print_diff(self, project_or_project_and_group: str, entity_config):
+
+        entity_in_gitlab = self.get_method(project_or_project_and_group)
+
+        DifferenceLogger.log_diff(
+            f"{self.configuration_name} changes",
+            entity_in_gitlab,
+            entity_config,
+        )

--- a/gitlabform/ui.py
+++ b/gitlabform/ui.py
@@ -1,11 +1,11 @@
 import json
-import logging
-
-import sys
 from typing import Any
+from urllib.error import URLError
 
 import luddite
 import pkg_resources
+import sys
+from cli_ui import debug as verbose
 from cli_ui import (
     message,
     info,
@@ -21,10 +21,7 @@ from cli_ui import (
     Symbol,
     Token,
 )
-from cli_ui import debug as verbose
-
 from packaging import version as packaging_version
-from urllib.error import URLError
 
 from gitlabform import EXIT_PROCESSING_ERROR, EXIT_INVALID_INPUT, Entities
 
@@ -223,7 +220,7 @@ def info_count(color, prefix, i: int, n: int, *rest: Token, **kwargs: Any) -> No
     info(color, prefix, reset, counter_str, reset, *rest, **kwargs)
 
 
-def to_json_str(a_dict: dict):
-    # the arguably easiest to read way of showing dict in a single line
+def to_str(a_dict: dict) -> str:
+    # arguably the most readable form of a dict in a single line
     # is JSON with sorted keys
     return json.dumps(a_dict, sort_keys=True)

--- a/gitlabform/ui.py
+++ b/gitlabform/ui.py
@@ -1,3 +1,6 @@
+import json
+import logging
+
 import sys
 from typing import Any
 
@@ -218,3 +221,9 @@ def info_count(color, prefix, i: int, n: int, *rest: Token, **kwargs: Any) -> No
     counter_format = "(%{}d/%d)".format(num_digits)
     counter_str = counter_format % (i, n)
     info(color, prefix, reset, counter_str, reset, *rest, **kwargs)
+
+
+def to_json_str(a_dict: dict):
+    # the arguably easiest to read way of showing dict in a single line
+    # is JSON with sorted keys
+    return json.dumps(a_dict, sort_keys=True)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,7 @@
 [pytest]
 filterwarnings =
     ignore::DeprecationWarning
+
+;uncomment below for debug logging ALWAYS, even if the tests are passing
+;log_cli = True
+;log_cli_level = DEBUG

--- a/tests/acceptance/test_group_settings.py
+++ b/tests/acceptance/test_group_settings.py
@@ -1,0 +1,35 @@
+from tests.acceptance import run_gitlabform
+
+
+class TestGroupSettings:
+    def test__edit_settings(self, gitlab, group):
+        settings = gitlab.get_group_settings(group)
+        assert settings["description"] != "foobar"
+
+        edit_group_settings = f"""
+        projects_and_groups:
+          {group}/*:
+            group_settings:
+              description: foobar
+        """
+
+        run_gitlabform(edit_group_settings, group)
+
+        settings = gitlab.get_group_settings(group)
+        assert settings["visibility"] == "internal"
+
+    def test__no_edit_needed(self, gitlab, group):
+        settings = gitlab.get_group_settings(group)
+        current_value = settings["path"]
+
+        edit_group_settings = f"""
+            projects_and_groups:
+              {group}/*:
+                group_settings:
+                  path: {current_value}
+            """
+
+        run_gitlabform(edit_group_settings, group)
+
+        settings = gitlab.get_group_settings(group)
+        assert settings["path"] == current_value


### PR DESCRIPTION
* Add LRU cache for all requests to get ids entities
 by name, as the ids don't change during a single
 app run.
* Minimize debug logging duplication,
* Introduce SingleEntityProcess that generalizes editing
 things that are single per project, f.e. settings
 or push rules set. It does not edit entities if there
 are not changes to be applied.