### PR TITLE
Accept code returned when user is already an owner

### DIFF
--- a/gitlabform/gitlab/schedules.py
+++ b/gitlabform/gitlab/schedules.py
@@ -49,7 +49,7 @@ class GitLabPipelineSchedules(GitLabCore):
             "projects/%s/pipeline_schedules/%s/take_ownership",
             (project_and_group_name, pipeline_schedule_id),
             method="POST",
-            expected_codes=[200, 201],
+            expected_codes=[200, 201, 403],  # TODO: stop accepting 403 after GitLab idempotency bug is fixed
         )
 
     def delete_pipeline_schedule(self, project_and_group_name, pipeline_schedule_id):


### PR DESCRIPTION
This is a temporary workaround for a idempotency bug
in GitLab.

See issue #361.